### PR TITLE
Use sync_notify instead of notify

### DIFF
--- a/lib/probe.ex
+++ b/lib/probe.ex
@@ -18,6 +18,6 @@ defmodule Probe do
   Send an event to be logged.
   """
   def notify(event),
-    do: GenEvent.notify(__MODULE__, event)
+    do: GenEvent.sync_notify(__MODULE__, event)
 
 end


### PR DESCRIPTION
Making event sends synchronous prevents the bog from overwhelming audit
logging and potentially losing audit events in the case of a crash.
